### PR TITLE
openvfd_drv: Fix building for Linux >= 5.0.0

### DIFF
--- a/driver/openvfd_drv.c
+++ b/driver/openvfd_drv.c
@@ -284,9 +284,17 @@ static long openvfd_dev_ioctl(struct file *filp, unsigned int cmd,
 	if (_IOC_NR(cmd) >= VFD_IOC_MAXNR)
 		return -ENOTTY;
 	if (_IOC_DIR(cmd) & _IOC_READ)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0))
+		err = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+#else
 		err = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+#endif
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0))
+		err = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+#else
 		err = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+#endif
 	if (err)
 		return -EFAULT;
 


### PR DESCRIPTION
'type' argument was removed from access_ok() function in https://github.com/torvalds/linux/commit/96d4f267e40f9509e8a66e2b39e8b95655617693