### PR TITLE
Add missing includes for OpenVFDService

### DIFF
--- a/OpenVFDService.c
+++ b/OpenVFDService.c
@@ -1,6 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <string.h>
+#include <sys/stat.h> 
+#include <unistd.h> 
 #include <fcntl.h>
 #include <errno.h>
 #include <time.h>


### PR DESCRIPTION
This appears a strange oversight, but I was unable to compile the OpenVFDService without explicitly including `string.h`, `sys/stat.h` and `unistd.h`. This PR addresses this issue