### PR TITLE
Update for kernel 6.12 API changes

### DIFF
--- a/driver/openvfd_drv.c
+++ b/driver/openvfd_drv.c
@@ -1042,7 +1042,7 @@ static int openvfd_driver_remove(struct platform_device *pdev)
 	kfree(pdata);
 	pdata = NULL;
 #endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,10,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,11,0)
 	return 0;
 #endif
 }


### PR DESCRIPTION
The attached PR updates `openvfd_drv.c` for compatibility with Linux Kernel 6.12 (Debian 13 version). and relates to issue #24.

This solution looks to patch the source code of `linux_openvfd` rather than hacking in a new header file, as per the linked issue.

I have tested that this compiles and installs under Kernel 6.12. I have not tested it under earlier kernels, however, I have confirmed when these changes were made in upstream Kernel:

## `gpio_device_find` callback argument changed
Callback argument changed from `void *` to `const void *`
Implemented in 6.9:
- 6.8: https://github.com/torvalds/linux/blob/e8f897f4afef0031fe618a8e94127a0934896aba/include/linux/gpio/driver.h#L629
- 6.9: https://github.com/torvalds/linux/blob/a38297e3fb012ddfa7ce0321a7e5a8daeb1872b6/include/linux/gpio/driver.h#L646

## struct `gpio_device_get_chip` introduced
Implemented in 6.7
- 6.6: Does not exist
- 6.7: https://github.com/torvalds/linux/blob/0dd3ee31125508cd67f7e7172247f05b7fd1753a/include/linux/gpio/driver.h#L776
## `platform_driver.remove` changed from `int` to `void`
Implemented in 6.11
- 6.10: https://github.com/torvalds/linux/blob/0c3836482481200ead7b416ca80c68a29cfdaabd/include/linux/platform_device.h#L247
- 6.11: https://github.com/torvalds/linux/blob/98f7e32f20d28ec452afb208f9cffc08448a2652/include/linux/platform_device.h#L245